### PR TITLE
Fixes #576 - EGGD SMR Apron colour code changed 

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -17,8 +17,7 @@
 16. AIRAC (1706) - Waypoint OBUBA Added - thanks to @trevorhannant (Trevor Hannant)
 17. AIRAC (1706) - Waypoint LEMGU added M17/UM17 - thanks to @trevorhannant (Trevor Hannant)
 18. AIRAC (1706) - Heathrow (EGLL) Ground Changes - thanks to @tasosb (Anastasios Mpithas)
-
-
+19. Bug - Bristol SMR Apron Colour Bug (smrGDApron) - thanks to @tasosb (Anastasios Mpithas)
 
 # Changes from release 2017/04 to 2017/05
 1. Enhancement - Improved colours for some elements of Manchester (EGCC) SMR - thanks to @cpawley (Chris Pawley)

--- a/Colours.txt
+++ b/Colours.txt
@@ -42,7 +42,7 @@
 #define smrCompassbase 16777215
 #define smrConstruction 150
 #define smrDarkApron 3026478
-#define smrGDapron 11908533
+#define smrGDapron 10066329
 #define smrGDbuilding 9142113
 #define smrGDgrass 7058795
 #define smrGDtaxiway 9474192


### PR DESCRIPTION
# Summary of changes
Changed the smrGDApron colour code on colours.txt from 11908533 to 10066329

# Screenshots (if necessary)
Sorry, no screenshots at the moment, but I have tested it and it works. Someone can check it by simply replacing the code above on UK.sct
