### PR TITLE
Fixes #1103 - EGHI/HH BAMBO (150) C->TCNW corrected

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,6 +7,7 @@
 6. AIRAC (1806) - EGLF frequency update - thanks to @indianbhaji (Eric Liu)
 7. AIRAC (1806) - EGMC frequency update - thanks to @indianbhaji (Eric Liu)
 8. AIRAC (1805) - EGNR runway heading update - thanks to @indianbhaji (Eric Liu)
+9. Bug - Fixed Daventry->TCNW EGHI/HH inbounds via BAMBO (150) agreement display - thanks to @hsugden (Harry Sugden)
 
 # Changes from release 2018/06 to 2018/07
 1. AIRAC (1806) - EGKK SMR updates (HAP removed) - thanks to @agentsquash (Alex Ashley)

--- a/Agreements/Internal/C_TCNW.txt
+++ b/Agreements/Internal/C_TCNW.txt
@@ -1,5 +1,5 @@
-COPX:*:*:BAMBO:EGHI:*:London AC Daventry:London TC NW:*:15000:BAMBO
-COPX:*:*:BAMBO:EGHH:*:London AC Daventry:London TC NW:*:15000:BAMBO
+COPX:*:*:EVSEM:EGHI:*:London AC Daventry:London TC NW:*:15000:BAMBO
+COPX:*:*:EVSEM:EGHH:*:London AC Daventry:London TC NW:*:15000:BAMBO
 
 COPX:*:*:NEDEX:EGLF:*:London AC Daventry:London TC NW:*:15000:NEDEX
 COPX:*:*:NEDEX:EGLK:*:London AC Daventry:London TC NW:*:15000:NEDEX


### PR DESCRIPTION
# Summary of changes

Copy of comment from the issue:

"My guess is that this has something to do with BAMBO being about 10 miles out of NW's airspace, and that the flight plan track for this routing only remains in NW's airspace for about 5 miles. I tried allowing TCNW to be a guest in Daventry's airspace, but this didn't seem to have an effect. However, changing the COPX point from BAMBO to EVSEM (just at the border between Daventry and TC NW's airspace) appears to make the agreement function correctly - though of course BAMBO is left as the label that the controller would see in the Sector Exist List.

I also checked (by logging on as TC NW on Sweatbox) that the 150 BAMBO appeared in the Sector Inbound List correctly, and that 110 RISIN for TC NW to TC SW displayed correctly once TC NW had the aircraft assumed."