### PR TITLE
Fixes #1793 Drop TCNE -> TCE and TCE -> LONE agreements on handoff

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,7 +14,7 @@
 13. AIRAC (1906) - Essex STAR's updated - thanks to @kye-taylor (Kye Taylor)
 14. AIRAC (1906) - Lower airways to RNAV - thanks to @artturnip (Adam Turner)
 15. AIRAC (1906) - Updated EGBB SIDs - thanks to @TomS03 (Tom Earl)
-x. Bug - Modify TCNE->TCE and TCE->LONE agreements so that LONE->EHAA_W agreeement displays properly on transfer - thanks to @artturnip (Adam Turner)
+16. Bug - Modify TCNE->TCE and TCE->LONE agreements so that LONE->EHAA_W agreeement displays properly on transfer - thanks to @artturnip (Adam Turner)
 
 # Changes from release 2019/04 to 2019/05
 1. Enhancement - EGBB ATIS frequency updated - thanks to @danielbutton (Daniel Button)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -14,6 +14,7 @@
 13. AIRAC (1906) - Essex STAR's updated - thanks to @kye-taylor (Kye Taylor)
 14. AIRAC (1906) - Lower airways to RNAV - thanks to @artturnip (Adam Turner)
 15. AIRAC (1906) - Updated EGBB SIDs - thanks to @TomS03 (Tom Earl)
+x. Bug - Modify TCNE->TCE and TCE->LONE agreements so that LONE->EHAA_W agreeement displays properly on transfer - thanks to @artturnip (Adam Turner)
 
 # Changes from release 2019/04 to 2019/05
 1. Enhancement - EGBB ATIS frequency updated - thanks to @danielbutton (Daniel Button)
@@ -22,7 +23,7 @@
 4. Bug - Remove Elksham VRP at EGGD - thanks to @artturnip (Adam Turner)
 5. AIRAC (1905) - Update EGXC squawk range - thanks to @artturnip (Adam Turner)
 6. Bug - Corrects Birmingham squawk range to valid range - thanks to @cbyworth (Chad Byworth)
-7. Enhancement - Format runway definitions so they are aligned - thanks to @artturip (Adam Turner)
+7. Enhancement - Format runway definitions so they are aligned - thanks to @artturnip (Adam Turner)
 8. AIRAC (1904) - EGD323 updates - thanks to @inventor02 (George Peppard)
 9. Enhancement - Separated RNAV airways into Lower (-245) and Higher (245+) - thanks to @hsugden (Harry Sugden)
 10. AIRAC (1905) - Lower airways to RNAV - thanks to @artturnip (Adam Turner)

--- a/Agreements/Internal/TCE_E.txt
+++ b/Agreements/Internal/TCE_E.txt
@@ -1,36 +1,36 @@
-COPX:EGLL:*:LEDBO:*:*:London TC East:London AC Clacton:23000:*:^TEDSA
-COPX:EGWU:*:LEDBO:*:*:London TC East:London AC Clacton:23000:*:^TEDSA
-COPX:EGLL:*:SOMVA:*:*:London TC East:London AC Clacton:23000:*:^PAAVO
-COPX:EGWU:*:SOMVA:*:*:London TC East:London AC Clacton:23000:*:^PAAVO
-COPX:EGLL:*:REDFA:*:*:London TC East:London AC Clacton:23000:*:^GASBA
-COPX:EGWU:*:REDFA:*:*:London TC East:London AC Clacton:23000:*:^GASBA
+COPX:EGLL:*:*:LEDBO:*:London TC East:London AC Clacton:23000:*:^TEDSA
+COPX:EGWU:*:*:LEDBO:*:London TC East:London AC Clacton:23000:*:^TEDSA
+COPX:EGLL:*:*:SOMVA:*:London TC East:London AC Clacton:23000:*:^PAAVO
+COPX:EGWU:*:*:SOMVA:*:London TC East:London AC Clacton:23000:*:^PAAVO
+COPX:EGLL:*:*:REDFA:*:London TC East:London AC Clacton:23000:*:^GASBA
+COPX:EGWU:*:*:REDFA:*:London TC East:London AC Clacton:23000:*:^GASBA
 
-COPX:EGGW:*:LEDBO:*:*:London TC East:London AC Clacton:23000:*:^TEDSA
-COPX:EGGW:*:SOMVA:*:*:London TC East:London AC Clacton:23000:*:^PAAVO
-COPX:EGGW:*:REDFA:*:*:London TC East:London AC Clacton:23000:*:^GASBA
+COPX:EGGW:*:*:LEDBO:*:London TC East:London AC Clacton:23000:*:^TEDSA
+COPX:EGGW:*:*:SOMVA:*:London TC East:London AC Clacton:23000:*:^PAAVO
+COPX:EGGW:*:*:REDFA:*:London TC East:London AC Clacton:23000:*:^GASBA
 
-COPX:EGKK:*:LEDBO:*:*:London TC East:London AC Clacton:23000:*:^TEDSA
-COPX:EGKB:*:LEDBO:*:*:London TC East:London AC Clacton:23000:*:^TEDSA
-COPX:EGKK:*:SOMVA:*:*:London TC East:London AC Clacton:23000:*:^PAAVO
-COPX:EGKB:*:SOMVA:*:*:London TC East:London AC Clacton:23000:*:^PAAVO
-COPX:EGKK:*:REDFA:*:*:London TC East:London AC Clacton:23000:*:^RATLO
-COPX:EGKB:*:REDFA:*:*:London TC East:London AC Clacton:23000:*:^RATLO
+COPX:EGKK:*:*:LEDBO:*:London TC East:London AC Clacton:23000:*:^TEDSA
+COPX:EGKB:*:*:LEDBO:*:London TC East:London AC Clacton:23000:*:^TEDSA
+COPX:EGKK:*:*:SOMVA:*:London TC East:London AC Clacton:23000:*:^PAAVO
+COPX:EGKB:*:*:SOMVA:*:London TC East:London AC Clacton:23000:*:^PAAVO
+COPX:EGKK:*:*:REDFA:*:London TC East:London AC Clacton:23000:*:^RATLO
+COPX:EGKB:*:*:REDFA:*:London TC East:London AC Clacton:23000:*:^RATLO
 
-COPX:EGSS:*:LEDBO:*:*:London TC East:London AC Clacton:21000:*:^LEDBO
-COPX:EGSC:*:LEDBO:*:*:London TC East:London AC Clacton:21000:*:^LEDBO
-COPX:EGSS:*:SOMVA:*:*:London TC East:London AC Clacton:21000:*:^RATLO
-COPX:EGSC:*:SOMVA:*:*:London TC East:London AC Clacton:21000:*:^RATLO
-COPX:EGSS:*:REDFA:*:*:London TC East:London AC Clacton:21000:*:^RATLO
-COPX:EGSC:*:REDFA:*:*:London TC East:London AC Clacton:21000:*:^RATLO
+COPX:EGSS:*:*:LEDBO:*:London TC East:London AC Clacton:21000:*:^LEDBO
+COPX:EGSC:*:*:LEDBO:*:London TC East:London AC Clacton:21000:*:^LEDBO
+COPX:EGSS:*:*:SOMVA:*:London TC East:London AC Clacton:21000:*:^RATLO
+COPX:EGSC:*:*:SOMVA:*:London TC East:London AC Clacton:21000:*:^RATLO
+COPX:EGSS:*:*:REDFA:*:London TC East:London AC Clacton:21000:*:^RATLO
+COPX:EGSC:*:*:REDFA:*:London TC East:London AC Clacton:21000:*:^RATLO
 
-COPX:EGLC:*:LEDBO:*:*:London TC East:London AC Clacton:21000:*:^LEDBO
-COPX:EGLC:*:SOMVA:*:*:London TC East:London AC Clacton:21000:*:^RATLO
-COPX:EGLC:*:REDFA:*:*:London TC East:London AC Clacton:21000:*:^RATLO
-COPX:EGLC:*:CLN:*:*:London TC East:London AC Clacton:21000:*:^CLN
+COPX:EGLC:*:*:LEDBO:*:London TC East:London AC Clacton:21000:*:^LEDBO
+COPX:EGLC:*:*:SOMVA:*:London TC East:London AC Clacton:21000:*:^RATLO
+COPX:EGLC:*:*:REDFA:*:London TC East:London AC Clacton:21000:*:^RATLO
+COPX:EGLC:*:*:CLN:*:London TC East:London AC Clacton:21000:*:^CLN
 
 ;Pre AIRAC 1813 Routings/Agreements
-COPX:EGLL:*:CLN:*:*:London TC East:London AC Clacton:23000:*:^CLN
-COPX:EGWU:*:CLN:*:*:London TC East:London AC Clacton:23000:*:^CLN
-COPX:EGKK:*:CLN:*:*:London TC East:London AC Clacton:23000:*:^CLN
-COPX:EGKB:*:CLN:*:*:London TC East:London AC Clacton:23000:*:^CLN
-COPX:EGGW:*:CLN:*:*:London TC East:London AC Clacton:23000:*:^CLN
+COPX:EGLL:*:*:CLN:*:London TC East:London AC Clacton:23000:*:^CLN
+COPX:EGWU:*:*:CLN:*:London TC East:London AC Clacton:23000:*:^CLN
+COPX:EGKK:*:*:CLN:*:London TC East:London AC Clacton:23000:*:^CLN
+COPX:EGKB:*:*:CLN:*:London TC East:London AC Clacton:23000:*:^CLN
+COPX:EGGW:*:*:CLN:*:London TC East:London AC Clacton:23000:*:^CLN

--- a/Agreements/Internal/TCNE_TCE.txt
+++ b/Agreements/Internal/TCNE_TCE.txt
@@ -1,31 +1,31 @@
-COPX:EGLL:*:LEDBO:*:*:London TC NE:London TC East:15000:*:^PAAVO
-COPX:EGWU:*:LEDBO:*:*:London TC NE:London TC East:15000:*:^PAAVO
-COPX:EGLL:*:SOMVA:*:*:London TC NE:London TC East:15000:*:^PAAVO
-COPX:EGWU:*:SOMVA:*:*:London TC NE:London TC East:15000:*:^PAAVO
-COPX:EGLL:*:REDFA:*:*:London TC NE:London TC East:15000:*:^GASBA
-COPX:EGWU:*:REDFA:*:*:London TC NE:London TC East:15000:*:^GASBA
+COPX:EGLL:*:*:LEDBO:*:London TC NE:London TC East:15000:*:^PAAVO
+COPX:EGWU:*:*:LEDBO:*:London TC NE:London TC East:15000:*:^PAAVO
+COPX:EGLL:*:*:SOMVA:*:London TC NE:London TC East:15000:*:^PAAVO
+COPX:EGWU:*:*:SOMVA:*:London TC NE:London TC East:15000:*:^PAAVO
+COPX:EGLL:*:*:REDFA:*:London TC NE:London TC East:15000:*:^GASBA
+COPX:EGWU:*:*:REDFA:*:London TC NE:London TC East:15000:*:^GASBA
 
-COPX:EGGW:*:LEDBO:*:*:London TC NE:London TC East:15000:*:^PAAVO
-COPX:EGGW:*:SOMVA:*:*:London TC NE:London TC East:15000:*:^PAAVO
-COPX:EGGW:*:REDFA:*:*:London TC NE:London TC East:15000:*:^GASBA
+COPX:EGGW:*:*:LEDBO:*:London TC NE:London TC East:15000:*:^PAAVO
+COPX:EGGW:*:*:SOMVA:*:London TC NE:London TC East:15000:*:^PAAVO
+COPX:EGGW:*:*:REDFA:*:London TC NE:London TC East:15000:*:^GASBA
 
-COPX:EGSS:*:CLN:*:*:London TC NE:London TC East:11000:*:^CLN
-COPX:EGSC:*:CLN:*:*:London TC NE:London TC East:11000:*:^CLN
+COPX:EGSS:*:*:CLN:*:London TC NE:London TC East:11000:*:^CLN
+COPX:EGSC:*:*:CLN:*:London TC NE:London TC East:11000:*:^CLN
 
-COPX:EGLC:*:SOMVA:*:*:London TC NE:London TC East:11000:*:^RATLO
-COPX:EGLC:*:CLN:*:*:London TC NE:London TC East:11000:*:^CLN
+COPX:EGLC:*:*:SOMVA:*:London TC NE:London TC East:11000:*:^RATLO
+COPX:EGLC:*:*:CLN:*:London TC NE:London TC East:11000:*:^CLN
 
-COPX:EGKK:*:LEDBO:*:*:London TC NE:London TC East:17000:*:^PAAVO
-COPX:EGKB:*:LEDBO:*:*:London TC NE:London TC East:17000:*:^PAAVO
-COPX:EGKK:*:SOMVA:*:*:London TC NE:London TC East:17000:*:^PAAVO
-COPX:EGKB:*:SOMVA:*:*:London TC NE:London TC East:17000:*:^PAAVO
-COPX:EGKK:*:REDFA:*:*:London TC NE:London TC East:17000:*:^RATLO
-COPX:EGKB:*:REDFA:*:*:London TC NE:London TC East:17000:*:^RATLO
+COPX:EGKK:*:*:LEDBO:*:London TC NE:London TC East:17000:*:^PAAVO
+COPX:EGKB:*:*:LEDBO:*:London TC NE:London TC East:17000:*:^PAAVO
+COPX:EGKK:*:*:SOMVA:*:London TC NE:London TC East:17000:*:^PAAVO
+COPX:EGKB:*:*:SOMVA:*:London TC NE:London TC East:17000:*:^PAAVO
+COPX:EGKK:*:*:REDFA:*:London TC NE:London TC East:17000:*:^RATLO
+COPX:EGKB:*:*:REDFA:*:London TC NE:London TC East:17000:*:^RATLO
 
 ;Pre AIRAC 1813 Routings/Agreements
-COPX:EGLL:*:CLN:*:*:London TC NE:London TC East:15000:*:^CLN
-COPX:EGWU:*:CLN:*:*:London TC NE:London TC East:15000:*:^CLN
-COPX:EGGW:*:CLN:*:*:London TC NE:London TC East:15000:*:^CLN
+COPX:EGLL:*:*:CLN:*:London TC NE:London TC East:15000:*:^CLN
+COPX:EGWU:*:*:CLN:*:London TC NE:London TC East:15000:*:^CLN
+COPX:EGGW:*:*:CLN:*:London TC NE:London TC East:15000:*:^CLN
 
-COPX:EGKK:*:CLN:*:*:London TC NE:London TC East:17000:*:^CLN
-COPX:EGKB:*:CLN:*:*:London TC NE:London TC East:17000:*:^CLN
+COPX:EGKK:*:*:CLN:*:London TC NE:London TC East:17000:*:^CLN
+COPX:EGKB:*:*:CLN:*:London TC NE:London TC East:17000:*:^CLN


### PR DESCRIPTION
Fixes #1793 

# Summary of changes

Change the field (FIX -> FIXAFTER, one colon to the right) for the TCNE -> TCE and TCE -> LONE agreement fixes to ensure LONE -> EHAA_W agreement displays properly once aircraft are transferred.

Correct a typo in my username for a previous changelog entry!