### PR TITLE
Fixes #2125 - Added missing NT/NV inbound agreements S28->East

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -26,6 +26,7 @@
 25. AIRAC (1912) - Coventry Information frequency updated and renamed - thanks to @verenion (Dean Lovett)
 26. AIRAC (1913) - Coventry SMR updated, updated taxiways and added new hold - thanks to @verenion (Dean Lovett)
 27. Enhancement - Added TC Midlands and amended AC Central/AC South boundary for 2020/01 - thanks to @cpawley (Chris Pawley)
+28. Bug - Added missing Newcastle (EGNT) and Durham (EGNV) inbound agreements, S28->East - thanks to @hsugden (Harry Sugden)
 
 # Changes from release 2019/12 to 2019/13
 1. AIRAC (1913) - EGTK Runway 11/29 Withdrawn, Runway 29 Threshold Coordinates Updated - thanks to @AleksMax (Aleks Nieszczerzewski)

--- a/Agreements/Internal/28_East.txt
+++ b/Agreements/Internal/28_East.txt
@@ -1,6 +1,11 @@
-;fixme POL45 or TNT also
 COPX:*:*:BETAX:EGNT:*:London S28:East:*:28000:BETAX
 COPX:*:*:BETAX:EGNV:*:London S28:East:*:28000:BETAX
 
+COPX:*:*:TNT:EGNT:*:London S28:East:*:28000:TNT
+COPX:*:*:TNT:EGNV:*:London S28:East:*:28000:TNT
+
 COPX:*:*:MAMUL:EGNT:*:London S28:East:*:28000:MAMUL25
 COPX:*:*:MAMUL:EGNV:*:London S28:East:*:28000:MAMUL25
+
+COPX:*:*:*:EGNT:*:London S28:East:*:28000:POL45
+COPX:*:*:*:EGNV:*:London S28:East:*:28000:POL45


### PR DESCRIPTION
Fixes #2125

# Summary of changes

Added agreements via TNT and POL45.

Since POL is well into East's sector, EuroScope wouldn't show the East controller the next agreement until they had passed POL if this were to be used in the COPX. So my logic is that if their route doesn't match any of the other 3 agreements, then they still need to be level at FL280, 45 miles before POL, so that can just be a catch-all!