### PR TITLE
Fixes #2712 - Ownership in Scottish/Copenhagen area

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -19,6 +19,7 @@
 19. Bug - Fixed S10->East Midlands/EGGP Inbound Agreements - thanks to @luketp (Luke Peters)
 20. Enhancement - Added guest ownership for S10->S13/14 LTMA inbound (transiting) agreements - thanks to @hsugden (Harry Sugden)
 21. Enhancement - Altered S7 -> IoM and IoM -> DUBN Dublin group inbound agreements - thanks to @hsugden (Harry Sugden)
+X. Bug - Fixed Scottish ownership in EKDK Delegated area - thanks to @hsugden (Harry Sugden)
 
 # Changes from release 2020/05 to 2020/06
 1. Enhancement - Add EGMD Lydd VRPs - thanks to @trevorhannant (Trevor Hannant)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -19,7 +19,7 @@
 19. Bug - Fixed S10->East Midlands/EGGP Inbound Agreements - thanks to @luketp (Luke Peters)
 20. Enhancement - Added guest ownership for S10->S13/14 LTMA inbound (transiting) agreements - thanks to @hsugden (Harry Sugden)
 21. Enhancement - Altered S7 -> IoM and IoM -> DUBN Dublin group inbound agreements - thanks to @hsugden (Harry Sugden)
-X. Bug - Fixed Scottish ownership in EKDK Delegated area - thanks to @hsugden (Harry Sugden)
+22. Bug - Fixed Scottish ownership in EKDK Delegated area - thanks to @hsugden (Harry Sugden)
 
 # Changes from release 2020/05 to 2020/06
 1. Enhancement - Add EGMD Lydd VRPs - thanks to @trevorhannant (Trevor Hannant)

--- a/Ownership/ScAC - East/Humber.txt
+++ b/Ownership/ScAC - East/Humber.txt
@@ -2,4 +2,15 @@ SECTOR:Humber:0:66000
 OWNER:SS:SE:S
 ALTOWNER:Observing Scottish FIR:O:SM:SS:SE:S
 ALTOWNER:Observing Scottish FIR (excl. STC_CTR):O:SM:SS:SE:S
-BORDER:Hum_Mon:SELN3:SELN4:Humber_EHAM:Hum_EHAA DB-195 Border:Hum_EKDK DB-195 Border:Tyne_Hum DK Del:Tyne_Hum
+
+SECTOR:Humber 1 (DB-660):0:66000
+OWNER:SS:SE:S
+ALTOWNER:Observing Scottish FIR:O:SM:SS:SE:S
+ALTOWNER:Observing Scottish FIR (excl. STC_CTR):O:SM:SS:SE:S
+BORDER:Hum_Mon:SELN4:SELN5:Humber_EHAM:Hum_EKDK DB-660:Tyne_Hum
+
+SECTOR:Humber 2 (DB-195):0:19500
+OWNER:SS:SE:S
+ALTOWNER:Observing Scottish FIR:O:SM:SS:SE:S
+ALTOWNER:Observing Scottish FIR (excl. STC_CTR):O:SM:SS:SE:S
+BORDER:Tyne_Hum DK Del:Hum_EKDK DB-195 Border:Hum_EHAA DB-195 Border:Hum_EKDK DB-660

--- a/Ownership/ScAC - East/Moray.txt
+++ b/Ownership/ScAC - East/Moray.txt
@@ -2,10 +2,21 @@ SECTOR:Moray:0:25500
 OWNER:SN:SE:S
 ALTOWNER:Observing Scottish FIR:O:SM:SN:SE:S
 ALTOWNER:Observing Scottish FIR (excl. STC_CTR):O:SM:SN:SE:S
+
+SECTOR:Moray 1 (DB-255):0:25500
+OWNER:SN:SE:S
+ALTOWNER:Observing Scottish FIR:O:SM:SN:SE:S
+ALTOWNER:Observing Scottish FIR (excl. STC_CTR):O:SM:SN:SE:S
 BORDER:Mor_BIRD:Mor_ENSV_N:Mor_ENSV:Mor_EKDK DB-660:Mor_Tyne:Mor_Mon:Heb_Mor 2:Heb_Mor Low:Heb_Mor 1
 
-SECTOR:Moray (255-660):25500:66000
+SECTOR:Moray 2 (255-660):25500:66000
 OWNER:SN:SE:S
 ALTOWNER:Observing Scottish FIR:O:SM:SN:SE:S
 ALTOWNER:Observing Scottish FIR (excl. STC_CTR):O:SM:SN:SE:S
 BORDER:Mor_BIRD:Mor_ENSV_N:Mor_ENSV:Mor_EKDK DB-660:Mor_Tyne:Mor_Mon:Heb_Mor 2:Mor Low Tri:Heb_Mor 1
+
+SECTOR:Moray 3 (DB-195):0:19500
+OWNER:SN:SE:S
+ALTOWNER:Observing Scottish FIR:O:SM:SN:SE:S
+ALTOWNER:Observing Scottish FIR (excl. STC_CTR):O:SM:SN:SE:S
+BORDER:Mor_ENSV-EKDK Delegated:Mor_EKDK DB-195 Border:Mor_Tyne DK Del:Mor_EKDK DB-660

--- a/Ownership/ScAC - East/Tyne.txt
+++ b/Ownership/ScAC - East/Tyne.txt
@@ -2,4 +2,15 @@ SECTOR:Tyne:0:66000
 OWNER:SS:SE:S
 ALTOWNER:Observing Scottish FIR:O:SM:SS:SE:S
 ALTOWNER:Observing Scottish FIR (excl. STC_CTR):O:SM:SS:SE:S
-BORDER:Tyne_Montrose:Tyne_Hum:Tyne_Hum DK Del:Tyne_EKDK DB-195 Border:Mor_Tyne DK Del:Mor_Tyne
+
+SECTOR:Tyne 1 (DB-660):0:66000
+OWNER:SS:SE:S
+ALTOWNER:Observing Scottish FIR:O:SM:SS:SE:S
+ALTOWNER:Observing Scottish FIR (excl. STC_CTR):O:SM:SS:SE:S
+BORDER:Tyne_Montrose:Tyne_Hum:Tyne_EKDK DB-660:Mor_Tyne
+
+SECTOR:Tyne 2 (DB-195):0:19500
+OWNER:SS:SE:S
+ALTOWNER:Observing Scottish FIR:O:SM:SS:SE:S
+ALTOWNER:Observing Scottish FIR (excl. STC_CTR):O:SM:SS:SE:S
+BORDER:Mor_Tyne DK Del:Tyne_EKDK DB-195 Border:Tyne_Hum DK Del:Tyne_EKDK DB-660


### PR DESCRIPTION
Fixes #2712

# Summary of changes

Ownership now split into its separate sections such that aircraft are predicted into/out of the airspace delegated to Copenhagen correctly

# Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/12017284/84831570-7adeff00-b023-11ea-9cb6-d2e692d705b1.png)
