### PR TITLE
Fixes #3184 - Updated S7 -> IOM Midlands inbound agreement

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -24,7 +24,7 @@
 23. Bug - Corrected OCAS Region coordinates adjacent to Berry Head CTA2/4 - thanks to @luke11brown (Luke Brown)
 24. Procedure Change - PC Bandbox frequency changed to 133.875 - thanks to @hsugden (Harry Sugden)
 25. Procedure Change - Updated splitting functionality for MPC sectors - thanks to @hsugden (Harry Sugden)
-26. Procedure Change - Updated S7 -> IoM Midlands Group inbound agreement - thanks to @GeekPro101 (Thomas Mills)
+26. Procedure Change - Updated S7 -> IoM Midlands Group inbound agreement - thanks to @GeekPro101 (Thomas Mills) and @hsugden (Harry Sugden)
 27. Procedure Change - Updated Stafa -> S29 Midlands outbound agreements - thanks to @AleksMax (Aleks Nieszczerzewski)
 28. Procedure Change - Updated S29 -> 7 EGNT NV outbound agreement - thanks to @AleksMax (Aleks Nieszczerzewski)
 29. Procedure Change - Updated S29 -> 7 Severn Group & TE outbound agreement - thanks to @AleksMax (Aleks Nieszczerzewski)

--- a/Agreements/Internal/7_IoM.txt
+++ b/Agreements/Internal/7_IoM.txt
@@ -2,13 +2,17 @@ COPX:PENIL:*:*:EIDW:*:London S7:Isle of Man:*:29000:|PENIL
 COPX:PENIL:*:*:EIWT:*:London S7:Isle of Man:*:29000:|PENIL
 COPX:PENIL:*:*:EIME:*:London S7:Isle of Man:*:29000:|PENIL
 
+COPX:*:*:DONAX:EGNX:*:London S7:Isle of Man:*:29000:DONAX
+COPX:*:*:DONAX:EGBB:*:London S7:Isle of Man:*:29000:DONAX
+COPX:*:*:DONAX:EGBE:*:London S7:Isle of Man:*:29000:DONAX
+
 COPX:*:*:ROLEX:EGNX:*:London S7:Isle of Man:*:29000:ROLEX
 COPX:*:*:ROLEX:EGBB:*:London S7:Isle of Man:*:29000:ROLEX
 COPX:*:*:ROLEX:EGBE:*:London S7:Isle of Man:*:29000:ROLEX
 
-COPX:*:*:DONAX:EGNX:*:London S7:Isle of Man:*:29000:DONAX
-COPX:*:*:DONAX:EGBB:*:London S7:Isle of Man:*:29000:DONAX
-COPX:*:*:DONAX:EGBE:*:London S7:Isle of Man:*:29000:DONAX
+COPX:*:*:ALAVA:EGNX:*:London S7:Isle of Man:*:29000:ALAVA
+COPX:*:*:ALAVA:EGBB:*:London S7:Isle of Man:*:29000:ALAVA
+COPX:*:*:ALAVA:EGBE:*:London S7:Isle of Man:*:29000:ALAVA
 
 COPX:*:*:BAGIT:EGNX:*:London S7:Isle of Man:*:29000:BAGIT
 COPX:*:*:BAGIT:EGBB:*:London S7:Isle of Man:*:29000:BAGIT


### PR DESCRIPTION
Fixes #3184

# Summary of changes

Missing ALAVA which is a valid route (Q36)