### PR TITLE
Lock compiler version in actions

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -13,13 +13,15 @@ jobs:
   build:
     name: "Compile Sectorfile"
     runs-on: ubuntu-latest
+    env:
+      COMPILER_VERSION: 1.4.0
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
 
       - name: Download Compiler
         run: |
-          curl -L --output compiler https://github.com/VATSIM-UK/sector-file-compiler/releases/latest/download/cli-linux-x64
+          curl -L --output compiler https://github.com/VATSIM-UK/sector-file-compiler/releases/download/$COMPILER_VERSION/cli-linux-x64
           chmod +x ./compiler
 
       - name: Set Build Version


### PR DESCRIPTION
# Summary of changes

Fix the compiler version in GitHub Actions so that any changes to the compiler don't break the compilation process until the SF team is ready.

# Screenshots (if necessary)

N/A