### PR TITLE
Fixes #3547 - Adds Ground Networks to the new Compiler Config

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Changes from release 2021/03 to 2021/04
+1. Enhancement - Added Ground Networks for SB files to Compiler Config - thanks to @GeekPro101 (Thomas Mills)
+
 # Changes from release 2021/02 to 2021/03
 1. Bug - Corrected TC East static boundary - thanks to @hsugden (Harry Sugden)
 2. Bug - Fixed Missing Mentoring APP Sector Lines for East Midlands (EGNX) - thanks to @AleksMax (Aleks Nieszczerzewski)

--- a/compiler.config.json
+++ b/compiler.config.json
@@ -58,17 +58,17 @@
                     ],
                     "ignore_missing": true
                 },
-                "ground_network": {
-                    "type": "files",
-                    "files": [
-                        "Ground_Network.txt"
-                    ],
-                    "ignore_missing": true
-                },
                 "geo": {
                     "type": "files",
                     "files": [
                         "Range_Rings.txt"
+                    ],
+                    "ignore_missing": true
+                },
+                "ground_network": {
+                    "type": "files",
+                    "files": [
+                        "Ground_Network.txt"
                     ],
                     "ignore_missing": true
                 },

--- a/compiler.config.json
+++ b/compiler.config.json
@@ -58,6 +58,13 @@
                     ],
                     "ignore_missing": true
                 },
+                "ground_network": {
+                    "type": "files",
+                    "files": [
+                        "Ground_Network.txt"
+                    ],
+                    "ignore_missing": true
+                },
                 "geo": {
                     "type": "files",
                     "files": [


### PR DESCRIPTION
Fixes #3547 

# Summary of changes

As per issue.
