### PR TITLE
Fixes #3553 - Added Missing RADAR section to Compiler Config

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,6 +3,7 @@
 2. Enhancement - Added Ground Networks for SB files to Compiler Config - thanks to @GeekPro101 (Thomas Mills)
 3. Error - Corrected Edinburgh (EGPH) Air Network STIRA Fixes - thanks to @GeekPro101 (Thomas Mills) and (James Taylor)
 4. Bug - Added Missing Alternate Ownership for Warton (EGNO) - thanks to @AleksMax (Aleks Nieszczerzewski)
+X. Bug - Added Missing RADAR section to Compiler Config - thanks to @AleksMax (Aleks Nieszczerzewski)
 
 # Changes from release 2021/02 to 2021/03
 1. Bug - Corrected TC East static boundary - thanks to @hsugden (Harry Sugden)

--- a/compiler.config.json
+++ b/compiler.config.json
@@ -326,6 +326,13 @@
                 "type": "folder",
                 "folder": "ARTCC/Danger Areas"
             },
+			"radar": {
+				"type": "files",
+				"files": [
+					"Misc/Radar Holes.txt",
+					"Misc/Radar Sites.txt"
+				]
+			},
             "artcc_low": {
                 "type": "folder",
                 "folder": "ARTCC/Low"


### PR DESCRIPTION
Fixes #3553 

# Summary of changes

As per the title.
