### PR TITLE
Fixes #3619 - Add terminals to Stansted (EGSS) SMR

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Changes from release 2020/03 to 2020/04
+1. New EGBP SMR added
+
 # Changes from release 2020/02 to 2020/03
 1. AIRAC (2003) - Doncaster CTA 13 Added - thanks to @AleksMax (Aleks Nieszczerzewski)
 2. AIRAC (2003) - EGLF Squawk Range Update - thanks to @Keanu73 (Keanu Czirjak)


### PR DESCRIPTION
Fixes #3619

Adds terminal buildings to the EGSS SMR file

![SS Afrer](https://user-images.githubusercontent.com/59621142/115227503-733b2b80-a108-11eb-8dc7-ae01324bcf5e.png)
