### PR TITLE
Fixes #3784 - Amended EGGD/FF/TE ESE ownership build order

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,7 +3,8 @@
 2. Enhancement - Further AC North Resectorisation Changes (addition of Alt Ownership) - thanks to @AleksMax (Aleks Nieszczerzewski)
 3. Bug - Sector lines for PC SE amended - thanks to @robbo599 (Lee Roberts)
 4. Enhancement - Updated Gloucester OCAS Region to reflect Cotswold CTA FUA - thanks to @danielbutton (Daniel Button)
-3. Bug - Fixed PE APP -> Montrose Outbound Agreement COPX - thanks to @danielbutton (Daniel Button)
+5. Bug - Fixed PE APP -> Montrose Outbound Agreement COPX - thanks to @danielbutton (Daniel Button)
+6. Enhancement - Amended ESE build order for Bristol, Cardiff and Exeter APP airspace to improve COPX display - thanks to @hsugden (Harry Sugden)
 
 # Changes from release 2021/07 to 2021/08
 1. Enhancement - Added EGNX Ground Networks - Thanks to @1adamf (Adam Farquharson, James Taylor, Dean Benavidez)

--- a/compiler.config.json
+++ b/compiler.config.json
@@ -73,7 +73,16 @@
                     ],
                     "ignore_missing": true
                 },
-                "ownership": {
+                "ownership": [
+                {
+                    "type": "files",
+                    "files": [
+                        "Ownership.txt"
+                    ],
+                    "ignore_missing": true
+                    "exclude_directory": ["EGGD", "EGFF", "EGTE"]
+                }, 
+                {
                     "type": "files",
                     "files": [
                         "Ownership.txt"


### PR DESCRIPTION
Fixes #3784

# Summary of changes

EGGD -> EGFF -> EGTE

(as originally required in https://github.com/VATSIM-UK/UK-Sector-File/pull/3736)