### PR TITLE
Remove Checks Suggestions

### DIFF
--- a/.build/bin/README.md
+++ b/.build/bin/README.md
@@ -1,1 +1,0 @@
-This file exists as a placeholder.

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
 
+      - name: Create Output Directory
+        run: mkdir .bin/
+
       - name: Download Compiler
         run: |
           curl -L --output compiler https://github.com/VATSIM-UK/sector-file-compiler/releases/download/$COMPILER_VERSION/cli-linux-x64
@@ -39,4 +42,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: UK Sector File
-          path: ".build/bin/UK.*"
+          path: ".bin/UK.*"

--- a/compiler.config.json
+++ b/compiler.config.json
@@ -1,8 +1,8 @@
 {
     "options": {
-        "sct_output": ".build/bin/UK.sct",
-        "ese_output": ".build/bin/UK.ese",
-        "rwy_output": ".build/bin/UK.rwy",
+        "sct_output": ".bin/UK.sct",
+        "ese_output": ".bin/UK.ese",
+        "rwy_output": ".bin/UK.rwy",
         "replace": [
             {
                 "token": "{YEAR}",


### PR DESCRIPTION
- Removes the need for the `.build/bin` folder to tidy up the repo
- Creates the output directory on the fly for uploading of artifacts