### PR TITLE
Fixes #4036 - Added Missing London Information Frequency

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Changes from release 2022/01 to 2022/02
+1. Enhancement - Added missing London Information frequency - thanks to @danielbutton (Daniel Button)
+
 # Changes from release 2021/13 to 2022/01
 1. AIRAC (2113) - Updated Oxford (EGTK) SMR - thanks to @SwietyMik (Mike Huk)
 2. Bug - Fixed unclosed border lines for London S25 - thanks to @hsugden (Harry Sugden)

--- a/Misc/Positions_Area Positions 3 UK Spares.txt
+++ b/Misc/Positions_Area Positions 3 UK Spares.txt
@@ -32,4 +32,5 @@ Scottish Control Montrose South:Scottish Control:126.920:SMS:E:SCO:CTR:-:-:3601:
 Scottish Control Galloway North:Scottish Control:121.370:STGN:S:STC:CTR:-:-:3601:3632::
 
 ;London Info
-London Information:London Information:125.470:LI:C:EGTT:CTR:-:-::
+London Information:London Information:125.470:LI:C:EGTT:CTR:1177:1177::
+London Information:London Information:124.750:LI:C:EGTT:CTR:1177:1177::


### PR DESCRIPTION
Fixes #4036

# Summary of changes

Added a definition for London Information 124.750. Uses identifier "LI" as per others.

# Screenshots (if necessary)

N/A
