### PR TITLE
Fixes #4074 - Added all Thames Group airfields to TC SW -> S23 agreement via KENET

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -20,6 +20,7 @@
 19. Procedure Change - Added EGMC Departures to TCNW -> TCSW CPT Agreement - thanks to @AleksMax (Aleks Nieszczerzewski)
 20. Procedure Change - Completed Internal 25 kHz frequency conversions - thanks to @AleksMax (Aleks Nieszczerzewski)
 21. Error - Updated Worthing and Dover Static Boundaries (Stars) to reflect current sectorisation - thanks to @hsugden (Harry Sugden)
+x. Procedure Change - Added all Thames Group airfields to TC SW -> S23 agreement via KENET - thanks to @ChrisXPP (Christoph Reule)
 
 # Changes from release 2021/13 to 2022/01
 1. AIRAC (2113) - Updated Oxford (EGTK) SMR - thanks to @SwietyMik (Mikolaj Huk)

--- a/Agreements/Internal/TCSW_23.txt
+++ b/Agreements/Internal/TCSW_23.txt
@@ -9,3 +9,6 @@ COPX:EGLF:*:KENET:*:*:London TC SW:London S23:13000:*:^CPT
 COPX:EGLK:*:KENET:*:*:London TC SW:London S23:13000:*:^CPT
 COPX:EGTF:*:KENET:*:*:London TC SW:London S23:13000:*:^CPT
 COPX:EGHL:*:KENET:*:*:London TC SW:London S23:13000:*:^CPT
+COPX:EGKB:*:KENET:*:*:London TC SW:London S23:13000:*:^CPT
+COPX:EGMC:*:KENET:*:*:London TC SW:London S23:13000:*:^CPT
+COPX:EGTO:*:KENET:*:*:London TC SW:London S23:13000:*:^CPT


### PR DESCRIPTION
Fixes #4074 

# Summary of changes

As per issue.

Added EGKB, EGMC and EGTO to the climbing FL130 agreement from TC SW to Sector 23.

# Changed file

Agreements/Internal/TCSW_23.txt
