### PR TITLE
Fixes #4517 - Reassigned Kirkwall (EGPA) ATIS freq to VHF

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,7 @@
 3. AIRAC (2213) - Removed Wycombe Air Park/Booker (EGTB) Runway 35 - thanks to @hazzas-99
 4. AIRAC (2213) - Editorial consistency of Belfast Aldergrove AD name - thanks to @hazzas-99
 5. AIRAC (2212) - Removed Fairford (EGVA) OKDID & GIBMI SIDs - thanks to @danielbutton (Daniel Button)
+6. Procedure Change - Reassigned Kirkwall (EGPA) ATIS frequency to VHF - thanks to @hazzas-99
 
 # Changes from release 2022/11 to 2022/12 
 1. AIRAC (2212) - Birmingham (EGBB) LUVUM RWY 15 SID redesignated - thanks to @lewishh (Lewis Hardcastle)

--- a/Airports/EGPA/Positions.txt
+++ b/Airports/EGPA/Positions.txt
@@ -1,4 +1,4 @@
 EGPA_A_APP:Kirkwall Approach:118.300:PAA:S:EGPA:APP:-:-:::N058.57.29.000:W002.54.02.000::
 EGPA_TWR:Kirkwall Tower:118.300:PAT:S:EGPA:TWR:-:-:::N058.57.29.000:W002.54.02.000::
 EGPA_I_TWR:Kirkwall Information:118.300:PAIN:S:EGPA_I:TWR:-:-:::N058.57.29.000:W002.54.02.000::
-EGPA_ATIS:Kirkwall Information:108.600:PAI:S:EGPA:ATIS:-:-::::::
+EGPA_ATIS:Kirkwall Information:119.425:PAI:S:EGPA:ATIS:-:-::::::


### PR DESCRIPTION
Fixes #4517

# Summary of changes

Assigned VHF frequency 119.425 to EGPA_ATIS