### PR TITLE
Fixes #4570 - Corrected Duxford (EGSU) Holding Point and Runway SMR Labels

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changes from release 2023/01 to 2023/02
 1. Bug - Corrected UK TACAN frequencies and coordinates as defined in UK MIL AIP - thanks to @chssn (Chris Parkinson)
 2. Enhancement - Added UK Overseas Territory TACAN frequencies and coordinates as defined in UK MIL AIP - thanks to @chssn (Chris Parkinson)
+3. Bug - Corrected Duxford (EGSU) holding point and runway names - thanks to @chssn (Chris Parkinson)
 
 # Changes from release 2022/13 to 2023/01
 1. Enhancement - Changed Liverpool (EGGP) SMR holding point labels from red to white - thanks to @zippy77777 (Darren Faux)

--- a/Airports/EGSU/SMR/Labels.txt
+++ b/Airports/EGSU/SMR/Labels.txt
@@ -1,7 +1,7 @@
 ;Holding Points
-"A" N052.05.40.374 E000.08.13.440 standHold
-"B" N052.05.38.311 E000.08.01.423 standHold
-"C" N052.05.24.623 E000.07.28.691 standHold
+"A24" N052.05.40.374 E000.08.13.440 standHold
+"B24" N052.05.38.311 E000.08.01.423 standHold
+"C06" N052.05.24.623 E000.07.28.691 standHold
 "D" N052.05.16.576 E000.07.21.023 standHold
 "E" N052.05.39.274 E000.08.20.078 standHold
 ;Parking
@@ -9,7 +9,7 @@
 "Eastern Apron" N052.05.41.583 E000.08.06.561 standHold
 "Grass Parking" N052.05.32.283 E000.07.47.059 standHold
 ;Runways
-"06" N052.05.13.850 E000.07.22.064 standHold
-"24" N052.05.38.501 E000.08.26.154 standHold
-"06 Grass" N052.05.21.774 E000.07.27.740 standHold
-"24 Grass" N052.05.36.190 E000.08.05.554 standHold
+"06R" N052.05.13.850 E000.07.22.064 standHold
+"24L" N052.05.38.501 E000.08.26.154 standHold
+"06L Grass" N052.05.21.774 E000.07.27.740 standHold
+"24R Grass" N052.05.36.190 E000.08.05.554 standHold


### PR DESCRIPTION
Fixes #4570 

# Summary of changes

Changed holding points SMR labels to reflect eAIP:
- A => A24
- B => B24
- C => C06

Changed runway SMR labels to reflect eAIP:
- 06 => 06R
- 24 => 24L
- 06 Grass => 06L Grass
- 24 Grass => 24R Grass

# Screenshots (if necessary)

![image](https://user-images.githubusercontent.com/33300267/215115233-5e9f2659-c4dc-4aaf-a7cb-e6a356994eed.png)
