### PR TITLE
Fixes #4746 - Default coastline colour

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,7 +3,7 @@
 2. Bug - Fixed online ring display for ESSEX_APP (now shows 1x ring rather than 3x) - thanks to @hazzas-99
 3. AIRAC (2306) - Updated Humberside (EGNJ) Runway Headings - thanks to @AmanT0mar (Aman Tomar)
 4. AIRAC (2305) - Updated Various MIL RWY Headings - thanks to @DuanBoomer (Chirag)
-5. Enhancement - Change default coastline colour  - thanks to @SamLefevre (Samuel Lefevre)
+5. Enhancement - Changed default coastline colour - thanks to @SamLefevre (Samuel Lefevre)
 
 # Changes from release 2023/04 to 2023/05
 1. Enhancement - Added TDA D597 - thanks to @robbo599 (Lee Roberts)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,6 +3,7 @@
 2. Bug - Fixed online ring display for ESSEX_APP (now shows 1x ring rather than 3x) - thanks to @hazzas-99
 3. AIRAC (2306) - Updated Humberside (EGNJ) Runway Headings - thanks to @AmanT0mar (Aman Tomar)
 4. AIRAC (2305) - Updated Various MIL RWY Headings - thanks to @DuanBoomer (Chirag)
+5. Enhancement - Change default coastline colour  - thanks to @SamLefevre (Samuel Lefevre)
 
 # Changes from release 2023/04 to 2023/05
 1. Enhancement - Added TDA D597 - thanks to @robbo599 (Lee Roberts)

--- a/Colours.txt
+++ b/Colours.txt
@@ -4,8 +4,8 @@
 #define building 10534048
 #define CCFAVA 11206655
 #define centrelinecolour 15790135
-#define coast 32896
-; @preserveComment Alternative colours for the above line, change to your preference. STC/PC (Grey) 5324604 Blue 9076039
+#define coast 9076039
+; @preserveComment Alternative colours for the above line, change to your preference. STC/PC (Grey) 5324604 Yellow 32896
 #define col_gate 3953980
 #define Edge 6589540
 #define Filled 6316128


### PR DESCRIPTION
Fixes #4746 

# Summary of changes

Change default from yellow to blue, explanation in issue

# Screenshots (if necessary)

Airports such as: Cardiff, Leeds, Glasgow, Southend, etc use blue on their radar
Only airport I could find with yellow is Liverpool, might be others such as exeter.
Main reason for change is that STC/PC profiles look off with the yellow and the grey doesn't work with all profiles, therefore best compromise is blue as the default.

Blue (compromise colour, works well on majority of profiles)
![image](https://github.com/VATSIM-UK/UK-Sector-File/assets/64741876/228cef09-12f1-4b09-b586-5617b1127f44)

Realistic Grey, only really works with STC/PC profile
![image](https://github.com/VATSIM-UK/UK-Sector-File/assets/64741876/979f903c-8e07-4ac6-a679-3bcca539d32f)

Yellow, similar with grey, doesn't work well on most profiles, especially ones that are used regularly
![image](https://github.com/VATSIM-UK/UK-Sector-File/assets/64741876/ea179d13-28e1-4417-bae9-d73d961bef30)
