### PR TITLE
Fixes #4919 - Update compiler version

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -15,7 +15,7 @@ jobs:
     name: "Compile Sectorfile"
     runs-on: ubuntu-latest
     env:
-      COMPILER_VERSION: 1.13.0
+      COMPILER_VERSION: 1.15.0
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ jobs:
     name: "Validate Sectorfile"
     runs-on: ubuntu-latest
     env:
-      COMPILER_VERSION: 1.13.0
+      COMPILER_VERSION: 1.15.0
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #4919

# Summary of changes
Update version to 1.15.0 ([see here](https://github.com/VATSIM-UK/sector-file-compiler/releases/tag/1.15.0))
