### PR TITLE
Fixes #4984 - EGAA inbounds now via BELZU

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,5 @@
+#. Bug - Corrected EGAA inbounds to descend via BELZU - thanks to @ChrisXPP (Christoph Reule)
+
 # Changes from release 2023/09a to 2023/10
 1. Bug - Corrected Scottish TMA Mentor (STC_M_CTR) callsign prefix for alternative ownership functionality - thanks to @rishab-alt
 2. Enhancement - Added ground network data for Bristol (EGGD) - thanks to @MikePike-collab (Mike Pike) & @luke11brown (Luke Brown)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,7 @@
-#. Bug - Corrected EGAA inbounds to descend via BELZU - thanks to @ChrisXPP (Christoph Reule)
-
 # Changes from release 2023/09a to 2023/10
 1. Bug - Corrected Scottish TMA Mentor (STC_M_CTR) callsign prefix for alternative ownership functionality - thanks to @rishab-alt
 2. Enhancement - Added ground network data for Bristol (EGGD) - thanks to @MikePike-collab (Mike Pike) & @luke11brown (Luke Brown)
+3. Bug - Corrected EGAA inbounds to descend via BELZU - thanks to @ChrisXPP (Christoph Reule)
 
 # Changes from release 2023/09 to 2023/09a
 1. Enhancement - Added Middle Wallop (EGVP) FATO (runway) and helicopter SIDs - thanks to @hazzas-99

--- a/Agreements/Airport/Ant_AA.txt
+++ b/Agreements/Airport/Ant_AA.txt
@@ -1,2 +1,2 @@
-COPX:*:*:*:EGAA:*:Antrim:AAAPP:*:10000:|BEL
+COPX:*:*:*:EGAA:*:Antrim:AAAPP:*:10000:|BELZU
 COPX:*:*:*:EGAC:*:Antrim:AAAPP:*:10000:|MAGEE


### PR DESCRIPTION
Fixes #4984 

# Summary of changes

Changed display of descending into EGAA from BEL to BELZU.

# Changed file

Agreements/Airport/Ant_AA.txt
