### PR TITLE
Fixes #5115 - Update contribution guide documentation

### DIFF
--- a/.github/Contributing.md
+++ b/.github/Contributing.md
@@ -22,7 +22,7 @@ If you're comfortable with contributing to Open Source projects on GitHub please
 
 **Please avoid** adding AIRAC related commits until you've seen an issue created for them - anything else is fair game.
 
-Please have a thorough read of the 1st-time Contributor's Guide: https://github.com/VATSIM-UK/UK-Sector-File/wiki/First-Time-Contributor's-Guide.
+Please have a thorough read of the [1st-time Contributor's Guide](https://github.com/VATSIM-UK/UK-Sector-File/blob/main/.github/First%20time%20contributors'%20guide.md).
 
 ## Testing the sector file
 

--- a/.github/Contributing.md
+++ b/.github/Contributing.md
@@ -52,9 +52,9 @@ The work-flow for submitting a new pull request is designed to be simple, but al
 * Commit your changes.
  * When writing commit messages, consider closing your issues via the commit message (by including "fix #22" or "fixes #22", for example ).
   * The issues will be referenced in the first instance and then closed once the MR is accepted.
-* **Add your changes to the CHANGELOG.md file** - this can be found in [UK-Sector-File/.github/CHANGELOG.md](https://github.com/VATSIM-UK/UK-Sector-File/blob/master/.github/CHANGELOG.md).
+* **Add your changes to the CHANGELOG.md file** - this can be found in [UK-Sector-File/.github/CHANGELOG.md](https://github.com/VATSIM-UK/UK-Sector-File/blob/main/.github/CHANGELOG.md).
 * Push the commit(s) to your fork.
-* Submit a pull request (PR) to the master branch.
+* Submit a pull request (PR) to the main branch.
 * The PR title should describe the change that has been made.
 * The PR description should confirm what changes have been made and how you know they're correct (with references).
  * Please include any relevant screenshots to prove the changes work - this is particularly important for SMRs. 

--- a/.github/First time contributors' guide.md
+++ b/.github/First time contributors' guide.md
@@ -4,7 +4,7 @@ This guide is intended for first time contributors, but should be followed along
 
 There is also the [Style Guide](https://github.com/VATSIM-UK/UK-Sector-File/blob/main/.github/Style%20Guide.md) which helps explain the details of how to get various aspects of the process correct.
 
-As well as this textual guide, there is a [YouTube video](LINK TBA) which explains the GitHub system and process using a worked example.
+As well as this textual guide, there is a [YouTube video](https://www.youtube.com/watch?v=FDddSD34f1o) which explains the GitHub system and process using a worked example.
 
 Thank you for your interest in contributing to the VATSIM UK Sector File. If you get stuck, and the information in [the wiki](https://github.com/VATSIM-UK/UK-Sector-File/wiki) is not enough to help you, please contact us on [Discord](https://www.vatsim.uk/discord) in the "sector-file-development" channel.
 

--- a/.github/First time contributors' guide.md
+++ b/.github/First time contributors' guide.md
@@ -1,3 +1,13 @@
+# Introduction
+
+This guide is intended for first time contributors, but should be followed alongside the [General Contributing Guide](https://github.com/VATSIM-UK/UK-Sector-File/blob/main/.github/Contributing.md).
+
+There is also the [Style Guide](https://github.com/VATSIM-UK/UK-Sector-File/blob/main/.github/Style%20Guide.md) which helps explain the details of how to get various aspects of the process correct.
+
+As well as this textual guide, there is a [YouTube video](LINK TBA) which explains the GitHub system and process using a worked example.
+
+Thank you for your interest in contributing to the VATSIM UK Sector File. If you get stuck, contact us on [Discord](https://www.vatsim.uk/discord) in the "sector-file-development" channel.
+
 # How to contribute for the first time
 
 If you haven't already, make a GitHub account and log in.

--- a/.github/First time contributors' guide.md
+++ b/.github/First time contributors' guide.md
@@ -47,7 +47,7 @@ In the GitHub desktop client, under 'current repository', under your username, s
 
 ![enter image description here](https://user-images.githubusercontent.com/14115426/101283451-5b56b100-37d2-11eb-95e6-dfeb70865cc8.png)
 
-Under 'Current branch' ensure 'master' (may also be titled 'main') is selected. 
+Under 'Current branch' ensure 'main' (may also be titled 'master') is selected.
 
 ![enter image description here](https://user-images.githubusercontent.com/14115426/101282290-4119d480-37cc-11eb-950a-b5eb7dde9f13.png)
 
@@ -158,7 +158,7 @@ If you want to do more issues, simply follow this guide from 'create new branch'
 
 ![enter image description here](https://user-images.githubusercontent.com/14115426/101295301-bad5b080-3814-11eb-8015-3a6b83ec2038.png)
 
-Simply ensure 'upstream/master' remains selected.
+Simply ensure 'upstream/main' remains selected.
 
 # Something broke
 

--- a/.github/First time contributors' guide.md
+++ b/.github/First time contributors' guide.md
@@ -6,7 +6,7 @@ There is also the [Style Guide](https://github.com/VATSIM-UK/UK-Sector-File/blob
 
 As well as this textual guide, there is a [YouTube video](LINK TBA) which explains the GitHub system and process using a worked example.
 
-Thank you for your interest in contributing to the VATSIM UK Sector File. If you get stuck, contact us on [Discord](https://www.vatsim.uk/discord) in the "sector-file-development" channel.
+Thank you for your interest in contributing to the VATSIM UK Sector File. If you get stuck, and the information in [the wiki](https://github.com/VATSIM-UK/UK-Sector-File/wiki) is not enough to help you, please contact us on [Discord](https://www.vatsim.uk/discord) in the "sector-file-development" channel.
 
 # How to contribute for the first time
 


### PR DESCRIPTION
Fixes #5115

# Summary of changes

Per issue. Also changed references to `master` branch to `main`

In draft until YouTube tutorial video published, then link needs updating.

Note: No changelog entry as documentation only.
