### PR TITLE
Fixes #5159 - Update Kirkwall (EGPA) ATIS frequency

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Changes from release 2023/13 to 2024/01
+#. AIRAC (2401) - Updated Kirkwall (EGPA) ATIS frequency - thanks to @ChrisXPP (Christoph Reule)
+
 # Changes from release 2023/12 to 2023/13
 1. Bug - Corrected Marham (EGYM) ATZ - thanks to @robbo599 (Lee Roberts)
 2. Enhancement - Added Hereford (EGVH) airport - thanks to @rishab-alt

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changes from release 2023/13 to 2024/01
-#. AIRAC (2401) - Updated Kirkwall (EGPA) ATIS frequency - thanks to @ChrisXPP (Christoph Reule)
+1. AIRAC (2401) - Updated Kirkwall (EGPA) ATIS frequency - thanks to @ChrisXPP (Christoph Reule)
 
 # Changes from release 2023/12 to 2023/13
 1. Bug - Corrected Marham (EGYM) ATZ - thanks to @robbo599 (Lee Roberts)

--- a/Airports/EGPA/Positions.txt
+++ b/Airports/EGPA/Positions.txt
@@ -1,3 +1,3 @@
 EGPA_A_APP:Kirkwall Approach:118.305:PAA:S:EGPA:APP:-:-:::N058.57.29.000:W002.54.02.000::
 EGPA_TWR:Kirkwall Tower:118.305:PAT:S:EGPA:TWR:-:-:::N058.57.29.000:W002.54.02.000::
-EGPA_ATIS:Kirkwall Information:119.425:PAI:S:EGPA:ATIS:-:-::::::
+EGPA_ATIS:Kirkwall Information:124.130:PAI:S:EGPA:ATIS:-:-::::::

--- a/Doc/UK VATSIM frequencies.txt
+++ b/Doc/UK VATSIM frequencies.txt
@@ -9,7 +9,6 @@ The following is a list of published UK VATSIM frequencies that differ from thei
 
 Guernsey ATIS           109.400, 118.900 on VATSIM (Guernsey radar freq)
 Inverness ATIS          109.200, 124.700 on VATSIM (ATIS frequency shared with Inverness VOR)
-Kirkwall ATIS           108.600, 119.425 (ATIS frequency shared with Kirkwall VOR)
 Stapleford Radio        122.800, 122.805 on VATSIM (Radio frequency shared with UNICOM)
 Stornoway ATIS          115.100, 121.600 on VATSIM (ATIS frequency shared with Stornoway VOR)
 Wick ATIS               113.600, 121.625 on VATSIM (ATIS frequency shared with Wick VOR)


### PR DESCRIPTION
Fixes #5159 

# Summary of changes

As per issue.

Kirkwall (EGPA) ATIS frequency updated to read 124.130.

# Changed file

`Airports/EGPA/Positions.txt`
